### PR TITLE
Include group, resource, and ui-schema yaml files

### DIFF
--- a/stack-package/.registry/app.yaml
+++ b/stack-package/.registry/app.yaml
@@ -23,6 +23,9 @@ owners:
 # Human readable company name.
 company: Upbound
 
+# Category that best describes this Stack
+category: Sample
+
 # Keywords that describe this application and help search indexing
 keywords:
 - "samples"
@@ -30,11 +33,8 @@ keywords:
 - "tutorials"
 
 # Links to more information about the application (about page, source code, etc.)
-links:
-- description: Website
-  url: "https://upbound.io"
-- description: Source Code
-  url: "https://github.com/crossplaneio/sample-stack"
+website: "https://upbound.io"
+source: "https://github.com/crossplaneio/sample-stack"
 
 # License SPDX name: https://spdx.org/licenses/
 license: Apache-2.0

--- a/stack-package/.registry/resources/samples.upbound.io/group.yaml
+++ b/stack-package/.registry/resources/samples.upbound.io/group.yaml
@@ -1,0 +1,3 @@
+title: Sample Group
+description: This is the description for the Sample Group
+category: Sample

--- a/stack-package/.registry/resources/samples.upbound.io/mytype/v1alpha1/mytype.ui-schema.yaml
+++ b/stack-package/.registry/resources/samples.upbound.io/mytype/v1alpha1/mytype.ui-schema.yaml
@@ -1,0 +1,4 @@
+uiSpecVersion: 0.3
+uiSpec:
+- title: MyType UI Title
+  description: MyType UI Description

--- a/stack-package/.registry/resources/samples.upbound.io/mytype/v1alpha1/resource.yaml
+++ b/stack-package/.registry/resources/samples.upbound.io/mytype/v1alpha1/resource.yaml
@@ -1,0 +1,5 @@
+id: mytype
+title: MyType
+title-plural: MyTypes
+description: This is MyType's Description
+category: Sample

--- a/stack-package/.registry/resources/samples.upbound.io/mytype/v1alpha1/ui-schema.yaml
+++ b/stack-package/.registry/resources/samples.upbound.io/mytype/v1alpha1/ui-schema.yaml
@@ -1,0 +1,4 @@
+uiSpecVersion: 0.3
+uiSpec:
+- title: Title
+  description: Description


### PR DESCRIPTION
Update the sample-stack based on the updated Crossplane Stacks design from https://github.com/crossplaneio/crossplane/pull/604
- links have been restructured in app.yaml
- include category in resources and app.yaml
- include title-plural in resource.yaml
- include ui-schema.yaml and a kind specific ui-schema.yaml

Also renames Extension to Stack in the remaining locations, per https://github.com/crossplaneio/crossplane/issues/668.